### PR TITLE
Switched to "Member-SUBM" status and added right boilerplate to SoTD

### DIFF
--- a/index.html
+++ b/index.html
@@ -7,9 +7,9 @@
             async class='remove'></script>
     <script class='remove'>
         var respecConfig = {
-            specStatus: 'unofficial',
+            specStatus: 'Member-SUBM',
             shortName: 'wot-model',
-            additionalCopyrightHolders: 'Copyright © 2015 EVRYTHNG',
+            overrideCopyright: 'Copyright © 2015 EVRYTHNG. This document is available under the <a href="http://www.w3.org/Consortium/Legal/copyright-documents">W3C Document License</a>. See the <a href="http://www.w3.org/Consortium/Legal/ipr-notice#Copyright">W3C Intellectual Rights Notice and Legal Disclaimers</a> for additional information.',
             editors: [
                 {
                     name: 'Vlad Trifa',
@@ -25,11 +25,6 @@
                     name: 'David Carrera',
                     company: 'Barcelona Supercomputing Center',
                     companyURL: 'http://bsc.es/'
-                },
-                {
-                    name: 'François Daoust',
-                    company: 'W3C',
-                    companyURL: 'http://www.w3.org'
                 }
             ],
             logos: [
@@ -108,6 +103,9 @@
     <p>
         This document is intended to be submitted as a W3C Member Submission and is based on work undertaken within the
         <a href="http://www.compose-project.eu/">COMPOSE</a> European project.
+    </p>
+    <p>
+        By publishing this document, W3C acknowledges that the <a href="http://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a> have made a formal Submission request to W3C for discussion. Publication of this document by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be allocating any resources to the issues addressed by it. This document is not the product of a chartered W3C group, but is published as potential input to the <a href="http://www.w3.org/Consortium/Process">W3C Process</a>. A <a href="http://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been published in conjunction with this Member Submission. Publication of acknowledged Member Submissions at the W3C site is one of the benefits of <a href="http://www.w3.org/Consortium/Prospectus/Joining">W3C Membership</a>. Please consult the requirements associated with Member Submissions of <a href="http://www.w3.org/Consortium/Patent-Policy-20040205.html#sec-submissions">section 3.3 of the W3C Patent Policy</a>. Please consult the complete <a href="http://www.w3.org/Submission">list of acknowledged W3C Member Submissions</a>.
     </p>
 </section>
 


### PR DESCRIPTION
ReSpec has limited support for Member Submissions. The "Member-SUBM"
specification status it defines does not really do the job properly. It's
still better than sticking to the "unofficial" status.

I added the right boilerplate to the "Status of This Document" section and
the right document license for the submission. I also removed myself from
the list of editors (mostly to streamline the submission process).

There remain a couple of things that will need to be changed manually in the
snapshot of the specification that will be sent along with the submission
request:
1. Drop the useless empty "Previous Version" item before the list of editors
2. Remove all the paragraphs after "Please consult the complete list of
   acknowledged W3C Member Submissions" in the Status of This Document section.
   These paragraphs are incorrectly added by ReSpec.
