### PR TITLE
Dropped boilerplate text from Status of This Document section

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,9 +104,6 @@
         This document is intended to be submitted as a W3C Member Submission and is based on work undertaken within the
         <a href="http://www.compose-project.eu/">COMPOSE</a> European project.
     </p>
-    <p>
-        By publishing this document, W3C acknowledges that the <a href="http://www.w3.org/Submission/@@@submissiondoc@@@">Submitting Members</a> have made a formal Submission request to W3C for discussion. Publication of this document by W3C indicates no endorsement of its content by W3C, nor that W3C has, is, or will be allocating any resources to the issues addressed by it. This document is not the product of a chartered W3C group, but is published as potential input to the <a href="http://www.w3.org/Consortium/Process">W3C Process</a>. A <a href="http://www.w3.org/Submission/@@@teamcomment@@@">W3C Team Comment</a> has been published in conjunction with this Member Submission. Publication of acknowledged Member Submissions at the W3C site is one of the benefits of <a href="http://www.w3.org/Consortium/Prospectus/Joining">W3C Membership</a>. Please consult the requirements associated with Member Submissions of <a href="http://www.w3.org/Consortium/Patent-Policy-20040205.html#sec-submissions">section 3.3 of the W3C Patent Policy</a>. Please consult the complete <a href="http://www.w3.org/Submission">list of acknowledged W3C Member Submissions</a>.
-    </p>
 </section>
 
 <section class='informative'>


### PR DESCRIPTION
The pull request I made to improve ReSpec support for Member Submissions
was merged so ReSpec now correctly takes care of the boilerplate text in
the Status of This Document section.
